### PR TITLE
add exit code on error

### DIFF
--- a/ios/ReactNativeConfig/BuildDotenvConfig.ruby
+++ b/ios/ReactNativeConfig/BuildDotenvConfig.ruby
@@ -31,6 +31,7 @@ rescue Errno::ENOENT
   puts("*** Missing .env file ****")
   puts("**************************")
   {} # set dotenv as an empty hash
+  exit 1
 end
 
 # create obj file that sets DOT_ENV as a NSDictionary


### PR DESCRIPTION
adding a non zero exit code here will terminate the build and ensure errors can be caught early